### PR TITLE
Add ARM value

### DIFF
--- a/toc
+++ b/toc
@@ -1,7 +1,7 @@
 {:navgroup: .navgroup}
 {:topicgroup: .topicgroup}
 
-{: .toc subcollection="containers" audience="compute" href="/docs/services/WorkloadScheduler/index.html"}
+{: .toc subcollection="containers" audience="compute" arm="286" href="/docs/services/WorkloadScheduler/index.html"}
 IBM Workload Scheduler
 
     {: .navgroup id="learn"}


### PR DESCRIPTION
I added the ARM value that is needed by IBM Cloud Support to integrate these service's documentation into ARM and our chat assistant. This change was previously requested by IBM Cloud Support, but it has remained incomplete. See Jenifer Schlotfeldt's ID Service Provider's Call notes from August 22, 2018 (https://ibm.ent.box.com/notes/164484265588). Please integrate these changes.